### PR TITLE
chore: add frappe dependency

### DIFF
--- a/flyout/pyproject.toml
+++ b/flyout/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    # "frappe~=15.0.0" # Installed and managed by bench.
+    "frappe~=15.0.0"
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- add frappe version pin to pyproject dependencies

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68c015c8492c8330a879eddaedeb6c52