### PR TITLE
Fix frappe app installation issues

### DIFF
--- a/flyout/MANIFEST.in
+++ b/flyout/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include flyout *.json *.md *.txt *.py *.js *.css *.scss *.svg *.html *.xml *.csv *.yml *.yaml
+recursive-include flyout/public *
+recursive-include flyout/templates *
+include license.txt
+include README.md


### PR DESCRIPTION
Enable Frappe app installation by correcting the Python package structure and adding `MANIFEST.in`.

---
<a href="https://cursor.com/background-agent?bcId=bc-034032f0-f3c7-4b93-ac56-06db38df9f7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-034032f0-f3c7-4b93-ac56-06db38df9f7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

