### PR TITLE
Install flyout frappe app

### DIFF
--- a/flyout/setup.py
+++ b/flyout/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+
+setup(
+	name="flyout",
+	version="0.0.1",
+	description="Sri Lanka's Migration Hub",
+	packages=find_packages(),
+	include_package_data=True,
+	install_requires=[],
+)
+


### PR DESCRIPTION
Add `setup.py` to the app root to allow `bench get-app` to detect the app name.

The `bench get-app` command failed with a `FileNotFoundError` because it requires a `setup.py` file to determine the app's package name. This PR adds a minimal `setup.py` to provide this essential metadata, enabling successful app installation.

---
<a href="https://cursor.com/background-agent?bcId=bc-95b4b194-17a5-4bbb-95fa-8dac8952fbe8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95b4b194-17a5-4bbb-95fa-8dac8952fbe8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

